### PR TITLE
Fix/global : ECS 배포시 RedisKeyExpiredListener Bean 생성불가 에러 해결

### DIFF
--- a/src/main/java/com/ip/ddangddangddang/domain/auction/event/AuctionKeyExpiredEvent.java
+++ b/src/main/java/com/ip/ddangddangddang/domain/auction/event/AuctionKeyExpiredEvent.java
@@ -1,10 +1,10 @@
-package com.ip.ddangddangddang.domain.auction.dto.request;
+package com.ip.ddangddangddang.domain.auction.event;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class AuctionKeyNotificationRequestDto {
+public class AuctionKeyExpiredEvent {
     private String message;
 }

--- a/src/main/java/com/ip/ddangddangddang/domain/auction/handler/AuctionEventHandler.java
+++ b/src/main/java/com/ip/ddangddangddang/domain/auction/handler/AuctionEventHandler.java
@@ -1,6 +1,6 @@
 package com.ip.ddangddangddang.domain.auction.handler;
 
-import com.ip.ddangddangddang.domain.auction.dto.request.AuctionKeyNotificationRequestDto;
+import com.ip.ddangddangddang.domain.auction.event.AuctionKeyExpiredEvent;
 import com.ip.ddangddangddang.domain.auction.service.AuctionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
@@ -13,8 +13,8 @@ public class AuctionEventHandler {
     private final AuctionService auctionService;
 
     @EventListener
-    public void AuctionKeyExpiredEvent(AuctionKeyNotificationRequestDto auctionKeyNotificationRequestDto){
-        auctionService.updateStatusToHold(auctionKeyNotificationRequestDto.getMessage());
+    public void AuctionKeyExpiredEvent(AuctionKeyExpiredEvent auctionKeyExpiredEvent){
+        auctionService.updateStatusToHold(auctionKeyExpiredEvent.getMessage());
     }
 
 }

--- a/src/main/java/com/ip/ddangddangddang/global/redis/RedisKeyExpiredListener.java
+++ b/src/main/java/com/ip/ddangddangddang/global/redis/RedisKeyExpiredListener.java
@@ -1,6 +1,6 @@
 package com.ip.ddangddangddang.global.redis;
 
-import com.ip.ddangddangddang.domain.auction.dto.request.AuctionKeyNotificationRequestDto;
+import com.ip.ddangddangddang.domain.auction.event.AuctionKeyExpiredEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
@@ -11,28 +11,33 @@ import org.springframework.stereotype.Component;
 @Component
 public class RedisKeyExpiredListener extends KeyExpirationEventMessageListener {
 
+    private final RedisMessageListenerContainer redisMessageListenerContainer;
     private final ApplicationEventPublisher applicationEventPublisher;
 
     /**
-     * Creates new {@link MessageListener} for {@code __keyEvent@*__:expired} messages.
-     *
-     * @param listenerContainer must not be {@literal null}.
+     * Creates new {@link MessageListener} for {@code __keyEvent@*__:expired} messages. must not be
+     * {@literal null}.
      */
     public RedisKeyExpiredListener(
         RedisMessageListenerContainer listenerContainer,
         ApplicationEventPublisher applicationEventPublisher
     ) {
         super(listenerContainer);
+        this.redisMessageListenerContainer = listenerContainer;
         this.applicationEventPublisher = applicationEventPublisher;
+    }
+
+    public void init() {
+        super.doRegister(redisMessageListenerContainer);
     }
 
     /**
      * @param message redis key
-     * @param pattern __keyEvent@*__:expired
-     * 만료시 알림을 받으면 이 메소드가 실행됨
+     * @param pattern __keyEvent@*__:expired 만료시 알림을 받으면 이 메소드가 실행됨
      */
     @Override
     public void onMessage(Message message, byte[] pattern) { //message = "auctionId: 1"
-        applicationEventPublisher.publishEvent(new AuctionKeyNotificationRequestDto(message.toString()));
+        applicationEventPublisher.publishEvent(new AuctionKeyExpiredEvent(message.toString()));
     }
 }
+


### PR DESCRIPTION
### ✅ PR 종류

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

--- 

### ⛏ 반영 브랜치

- Fix/global -> dev

---

### 📑 변경 사항

- ECS 배포시 RedisKeyExpiredListener Bean 생성불가 에러 해결
- AuctionKeyNotificationRequestDto를 AuctionKeyExpiredEvent로 이름을 변경했습니다.(의미상 적절하다 판단)
---

### 👀 중요하게 확인할 부분

- AuctionKeyExpiredEvent이라는 클래스로 이름을 지었습니다. 컨벤션에 맞지 않다고 판단되면 같이 이야기를 해봅시다!
---
